### PR TITLE
Fix: "NuPlayerDecoder: add synchronous call pause() to ensure decoder…

### DIFF
--- a/media/libmediaplayerservice/nuplayer/NuPlayerDecoderPassThrough.h
+++ b/media/libmediaplayerservice/nuplayer/NuPlayerDecoderPassThrough.h
@@ -56,7 +56,6 @@ protected:
     sp<Renderer> mRenderer;
     size_t mAggregateBufferSizeBytes;
     int64_t mSkipRenderingUntilMediaTimeUs;
-    bool mPaused;
     bool mReachedEOS;
 
     // Used by feedDecoderInputData to aggregate small buffers into


### PR DESCRIPTION
… will not request or send out data."
- Missing from backport

Change-Id: I562d28a4770aec2f9c547c482e79cca49be9dbb9
