### PR TITLE
nuplayer: Enable PCM offload for any source

### DIFF
--- a/include/media/AudioTrack.h
+++ b/include/media/AudioTrack.h
@@ -624,7 +624,7 @@ private:
      */
             status_t    obtainBuffer(Buffer* audioBuffer, const struct timespec *requested,
                                      struct timespec *elapsed = NULL, size_t *nonContig = NULL);
-     friend struct ExtendedMediaUtils;
+     friend struct AVMediaUtils;
 public:
 
     /* Public API for TRANSFER_OBTAIN mode.

--- a/media/libavextensions/mediaplayerservice/AVNuUtils.cpp
+++ b/media/libavextensions/mediaplayerservice/AVNuUtils.cpp
@@ -55,21 +55,11 @@
 namespace android {
 
 static bool is24bitPCMOffloadEnabled() {
-    char propPCMOfload[PROPERTY_VALUE_MAX] = {0};
-    property_get("audio.offload.pcm.24bit.enable", propPCMOfload, "0");
-    if (!strncmp(propPCMOfload, "true", 4) || atoi(propPCMOfload))
-        return true;
-    else
-        return false;
+    return property_get_bool("audio.offload.pcm.24bit.enable", false);
 }
 
 static bool is16bitPCMOffloadEnabled() {
-    char propPCMOfload[PROPERTY_VALUE_MAX] = {0};
-    property_get("audio.offload.pcm.16bit.enable", propPCMOfload, "0");
-    if (!strncmp(propPCMOfload, "true", 4) || atoi(propPCMOfload))
-        return true;
-    else
-        return false;
+    return property_get_bool("audio.offload.pcm.16bit.enable", false);
 }
 
 sp<MetaData> AVNuUtils::createPCMMetaFromSource(const sp<MetaData> &sMeta) {


### PR DESCRIPTION
- Use the raw PCM format to perform the early open of the audio sink.
  This ensures that the renderer will do the same.
- Fill in stubs for timestamp and position calculation. This fixes
  underruns and other issues.

Change-Id: I8d761e523194cc12f387b4b2aa1594536e56da01
