### PR TITLE
libmedia: correct latency computing for TRANSFER_SYNC

### DIFF
--- a/media/libmedia/AudioRecord.cpp
+++ b/media/libmedia/AudioRecord.cpp
@@ -276,7 +276,8 @@ status_t AudioRecord::set(
     mActive = false;
     mUserData = user;
     // TODO: add audio hardware input latency here
-    if (mTransfer == TRANSFER_CALLBACK) {
+    if (mTransfer == TRANSFER_CALLBACK ||
+            mTransfer == TRANSFER_SYNC) {
         mLatency = (1000*mNotificationFramesAct) / sampleRate;
     } else {
         mLatency = (1000*mFrameCount) / sampleRate;


### PR DESCRIPTION
- Compute the track latency by frame count returned
  from audio hal when in TRANSFER_SYNC mode

Change-Id: If7bbf780abc8e141eb35eea44c01c583b1290d3c
