### PR TITLE
av: Add support for loading audio_effects_vendor.conf

### DIFF
--- a/media/libeffects/factory/EffectsFactory.c
+++ b/media/libeffects/factory/EffectsFactory.c
@@ -456,7 +456,9 @@ int init() {
     if (ignoreFxConfFiles) {
         ALOGI("Audio effects in configuration files will be ignored");
     } else {
-        if (access(AUDIO_EFFECT_VENDOR_CONFIG_FILE, R_OK) == 0) {
+        if (access(AUDIO_EFFECT_VENDOR_CONFIG_FILE2, R_OK) == 0) {
+            loadEffectConfigFile(AUDIO_EFFECT_VENDOR_CONFIG_FILE2);
+        } else if (access(AUDIO_EFFECT_VENDOR_CONFIG_FILE, R_OK) == 0) {
             loadEffectConfigFile(AUDIO_EFFECT_VENDOR_CONFIG_FILE);
         } else if (access(AUDIO_EFFECT_DEFAULT_CONFIG_FILE, R_OK) == 0) {
             loadEffectConfigFile(AUDIO_EFFECT_DEFAULT_CONFIG_FILE);

--- a/services/audiopolicy/service/AudioPolicyEffects.cpp
+++ b/services/audiopolicy/service/AudioPolicyEffects.cpp
@@ -40,7 +40,9 @@ namespace android {
 AudioPolicyEffects::AudioPolicyEffects()
 {
     // load automatic audio effect modules
-    if (access(AUDIO_EFFECT_VENDOR_CONFIG_FILE, R_OK) == 0) {
+    if (access(AUDIO_EFFECT_VENDOR_CONFIG_FILE2, R_OK) == 0) {
+        loadAudioEffectConfig(AUDIO_EFFECT_VENDOR_CONFIG_FILE2);
+    } else if (access(AUDIO_EFFECT_VENDOR_CONFIG_FILE, R_OK) == 0) {
         loadAudioEffectConfig(AUDIO_EFFECT_VENDOR_CONFIG_FILE);
     } else if (access(AUDIO_EFFECT_DEFAULT_CONFIG_FILE, R_OK) == 0) {
         loadAudioEffectConfig(AUDIO_EFFECT_DEFAULT_CONFIG_FILE);


### PR DESCRIPTION
- In case a device has a /vendor partition which cannot be
  modified, this allows us to short-circuit the audio_effects.conf
  file which might be placed there with one of our own which
  lives on /system.

Change-Id: Ief87bd4cfba2c3188b0dff122d91f773b7f3d92d
