### PR TITLE
av: "ACodec: update native window crop rectangle" depends on QCOM

### DIFF
--- a/media/libstagefright/ACodec.cpp
+++ b/media/libstagefright/ACodec.cpp
@@ -936,6 +936,7 @@ status_t ACodec::setupNativeWindowSizeFormatAndUsage(
 #endif
             mRotationDegrees,
             usage);
+#ifdef QCOM_HARDWARE
     if (err == OK) {
         OMX_CONFIG_RECTTYPE rect;
         InitOMXParams(&rect);
@@ -953,6 +954,7 @@ status_t ACodec::setupNativeWindowSizeFormatAndUsage(
             err = native_window_set_crop(nativeWindow, &crop);
         }
     }
+#endif
     return err;
 }
 


### PR DESCRIPTION
Change-Id: If0cc81468ab7ee8fa0ec374a9f23e4004e7cb212
