### PR TITLE
Revert "Stagefright: Allow setting high-framerates in CameraSource"

### DIFF
--- a/media/libstagefright/CameraSource.cpp
+++ b/media/libstagefright/CameraSource.cpp
@@ -325,12 +325,6 @@ status_t CameraSource::isCameraColorFormatSupported(
     return OK;
 }
 
-static int32_t getHighSpeedFrameRate(const CameraParameters& params) {
-    const char* hsr = params.get("video-hsr");
-    int32_t rate = (hsr != NULL && strncmp(hsr, "off", 3)) ? atoi(hsr) : 0;
-    return rate > 240 ? 240 : rate;
-}
-
 /*
  * Configure the camera to use the requested video size
  * (width and height) and/or frame rate. If both width and
@@ -383,10 +377,6 @@ status_t CameraSource::configureCamera(
                 params->get(CameraParameters::KEY_SUPPORTED_PREVIEW_FRAME_RATES);
         CHECK(supportedFrameRates != NULL);
         ALOGV("Supported frame rates: %s", supportedFrameRates);
-        if (getHighSpeedFrameRate(*params)) {
-            ALOGI("Use default 30fps for HighSpeed %dfps", frameRate);
-            frameRate = 30;
-        }
         char buf[4];
         snprintf(buf, 4, "%d", frameRate);
         if (strstr(supportedFrameRates, buf) == NULL) {
@@ -488,8 +478,6 @@ status_t CameraSource::checkFrameRate(
         ALOGE("Failed to retrieve preview frame rate (%d)", frameRateActual);
         return UNKNOWN_ERROR;
     }
-    int32_t highSpeedRate = getHighSpeedFrameRate(params);
-    frameRateActual = highSpeedRate ? highSpeedRate : frameRateActual;
 
     // Check the actual video frame rate against the target/requested
     // video frame rate.


### PR DESCRIPTION
This reverts commit b5ccf81c19a7e9ce9b330abe734f1bae76d50796.

That patch breaks "High Speed 60 FPS"
and it fails in CameraSource::checkFrameRate
which it compares the preview frame rate:
Failed to set preview frame rate to 30 fps. The actual frame rate is 60.

SAMBAR-1261

Change-Id: I6adf1432bf901e8ba37b1b86621e117e77cbf853
