### PR TITLE
AVUtils: hevc: Return 0 when codec data is malformed

### DIFF
--- a/media/libavextensions/stagefright/AVUtils.cpp
+++ b/media/libavextensions/stagefright/AVUtils.cpp
@@ -448,7 +448,7 @@ status_t AVUtils::HEVCMuxer::makeHEVCCodecSpecificData(
     List<HEVCParamSet> picParamSets;
 
     if ((*codecSpecificDataSize = parseHEVCCodecSpecificData(data, size,
-                                   vidParamSets, seqParamSets, picParamSets)) <= 0) {
+                                   vidParamSets, seqParamSets, picParamSets)) == 0) {
         ALOGE("cannot parser codec specific data, bailing out");
         return ERROR_MALFORMED;
     }
@@ -885,12 +885,12 @@ size_t AVUtils::HEVCMuxer::parseHEVCCodecSpecificData(
             }
         } else {
             ALOGE("Only VPS, SPS and PPS Nal units are expected");
-            return ERROR_MALFORMED;
+            return 0;
         }
 
         if (nextStartCode == NULL) {
             ALOGE("Next start code is NULL");
-            return ERROR_MALFORMED;
+            return 0;
         }
 
         // Move on to find the next parameter set


### PR DESCRIPTION
This was returning ERROR_MALFORMED, which is a negative value,
since the function prototype returns size_t, it would be converted
to somewhere near 2**32 and would never fall into the actual error
checking clause in AVUtils::HEVCMuxer::makeHEVCCodecSpecificData.

Fixes android.mediastress.cts.HEVCR1080pAacLongPlayerTest#testPlay00

Ticket: CYNGNOS-1683
Change-Id: I13e6a76cb0ee4a6b730e1eb1023320b74a0539c7
